### PR TITLE
set lambda function timeout to 30 seconds for all functions.

### DIFF
--- a/sam-template.yml
+++ b/sam-template.yml
@@ -20,6 +20,7 @@ Resources:
       Policies:
         - AWSStepFunctionsFullAccess
         - CloudWatchLogsFullAccess
+      Timeout: 30
       Environment:
         Variables:
           STATE_MACHINE_ARN: !Ref ImagePipelineStateMachine
@@ -38,6 +39,7 @@ Resources:
       Policies:
         - AmazonRekognitionFullAccess
         - CloudWatchLogsFullAccess
+      Timeout: 30
   ImageResize:
     Type: 'AWS::Serverless::Function'
     Properties:
@@ -61,6 +63,7 @@ Resources:
       Policies:
         - AmazonDynamoDBFullAccess
         - CloudWatchLogsFullAccess
+      Timeout: 30
       Environment:
         Variables:
           TABLE_NAME: !Ref ImageDb
@@ -73,6 +76,7 @@ Resources:
       Policies:
         - AmazonDynamoDBReadOnlyAccess
         - CloudWatchLogsFullAccess
+      Timeout: 30
       Environment:
         Variables:
           TABLE_NAME: !Ref ImageDb

--- a/template.yml
+++ b/template.yml
@@ -20,6 +20,7 @@ Resources:
       Policies:
         - AWSStepFunctionsFullAccess
         - CloudWatchLogsFullAccess
+      Timeout: 30
       Environment:
         Variables:
           STATE_MACHINE_ARN: !Ref ImagePipelineStateMachine
@@ -63,6 +64,7 @@ Resources:
       Policies:
         - AmazonDynamoDBFullAccess
         - CloudWatchLogsFullAccess
+      Timeout: 30
       Environment:
         Variables:
           TABLE_NAME: !Ref ImageDb
@@ -75,6 +77,7 @@ Resources:
       Policies:
         - AmazonDynamoDBReadOnlyAccess
         - CloudWatchLogsFullAccess
+      Timeout: 30
       Environment:
         Variables:
           TABLE_NAME: !Ref ImageDb


### PR DESCRIPTION
I noticed that some of the executions timed out at 3 seconds. Setting it at 30 seconds would help avoid it.